### PR TITLE
Adding Edit Dashboard feature (#35)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postcss-loader": "3.0.0",
     "postcss-preset-env": "6.0.6",
     "postcss-safe-parser": "4.0.1",
-    "query-string": "^6.2.0",
+    "query-string": "^5.1.1",
     "react": "^16.8.3",
     "react-app-polyfill": "^0.1.1",
     "react-autobind": "^1.0.6",

--- a/src/dashboard-modal.tsx
+++ b/src/dashboard-modal.tsx
@@ -1,6 +1,7 @@
 import { observer } from "mobx-react";
 import * as React from 'react';
 const autobind = require('react-autobind');
+const queryString = require('query-string');
 
 import { CircularProgress, Button, TextField, InputAdornment, IconButton, Tooltip, ClickAwayListener } from '@material-ui/core';
 import Select from 'react-select';
@@ -58,6 +59,7 @@ class DashboardModal extends React.Component<any, ModalState> {
     if (nameOptions.length === 0){
       this.getNames();
     }
+    this.fillSelectedOptions();
   }
 
   render() {
@@ -153,6 +155,21 @@ class DashboardModal extends React.Component<any, ModalState> {
       };
       return nameOption;
     });
+  }
+
+  private fillSelectedOptions() {
+    const urlParams = queryString.parse(location.search);
+    if ("q" in urlParams) {
+      const items = urlParams.q.split("|");
+      const selectedOptions: NameOption[] = [];
+      for (const item of items) {
+        selectedOptions.push({
+          value: item,
+          label: item
+        });
+      }
+      this.setState({ selectedOptions });
+    }
   }
 
   private createDashboardUrl() {


### PR DESCRIPTION
I changed `query-string` version for older browser compatibility, as shown on [its readme](https://github.com/sindresorhus/query-string#install).

In the example below, we can see how the modal is behaving when the url contains items, and how it ignores invalid options.

![screen shot 2019-03-06 at 3 56 22 pm](https://user-images.githubusercontent.com/5158147/53906016-a3a6d500-4028-11e9-9345-8de380527c02.png)
